### PR TITLE
Silence some warnings by ansible and ansible-lint

### DIFF
--- a/tasks/cleanup.yml
+++ b/tasks/cleanup.yml
@@ -2,17 +2,19 @@
 - name: apt-get clean
   become: true
   command: apt-get clean
-  warn: false  # module "apt" does not support the "clean" subcommand
+  args:
+    warn: false  # module "apt" does not support the "clean" subcommand
   tags: skip_ansible_lint
-  #   301: not worth it
-  #   303: module "apt" does not support the "clean" subcommand
+    # 301: not worth it
+    # 303: module "apt" does not support the "clean" subcommand
 
 - name: wipe apt lists
   become: true
   shell: "rm -rf /var/lib/apt/lists/*"
-  warn: false  # module "file" does not support wildcards
+  args:
+    warn: false  # module "file" does not support wildcards
   tags: skip_ansible_lint
-  #   301: not worth it
+    # 301: not worth it
 
 - name: wipe vm user cache
   become: true

--- a/tasks/cleanup.yml
+++ b/tasks/cleanup.yml
@@ -2,10 +2,17 @@
 - name: apt-get clean
   become: true
   command: apt-get clean
+  warn: false  # module "apt" does not support the "clean" subcommand
+  tags: skip_ansible_lint
+  #   301: not worth it
+  #   303: module "apt" does not support the "clean" subcommand
 
 - name: wipe apt lists
   become: true
   shell: "rm -rf /var/lib/apt/lists/*"
+  warn: false  # module "file" does not support wildcards
+  tags: skip_ansible_lint
+  #   301: not worth it
 
 - name: wipe vm user cache
   become: true


### PR DESCRIPTION
For context, here are the error codes in question ([from here](https://docs.ansible.com/ansible-lint/rules/default_rules.html)):


ID | Version Added | Sample Message | Description
-- | -- | -- | --
E301 | historic | Commands should not change things if nothing needs doing | Commands should either read information (and thus set changed_when) or not do something if it has already been done (using creates/removes) or only do it if another check has a particular result (when)
E303 | historic | Using command rather than module | Executing a command when there is an Ansible module is generally a bad idea

